### PR TITLE
ci: remove auto assign PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,17 +7,6 @@ env:
     NODE_VERSION: '12.x'
 
 jobs:
-    meta:
-        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        steps:
-            - name: Assign PR to author
-              uses: samspills/assign-pr-to-author@v1.0
-              if: github.event_name == 'pull_request' && github.event.action == 'opened'
-              with:
-                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
-
     setup:
         name: Setup
         runs-on: ubuntu-latest


### PR DESCRIPTION
Not auto assign pull request because it has a bug somewhere 